### PR TITLE
use delta OSS for UT

### DIFF
--- a/dp/flow.py
+++ b/dp/flow.py
@@ -18,11 +18,11 @@ display(df_prime)
 
 # COMMAND ----------
 
-persist(df_prime, "/tmp/roy/hw_parquet_table")
+persist(df_prime, "/tmp/roy/hw_delta_table")
 
 # COMMAND ----------
 
-display(spark.read.format("parquet").load("/tmp/roy/hw_parquet_table"))
+display(spark.read.format("delta").load("/tmp/roy/hw_delta_table"))
 
 # COMMAND ----------
 

--- a/lib/udfs.py
+++ b/lib/udfs.py
@@ -9,5 +9,5 @@ def xform(df):
 	return df.select(multiply(col("x"), col("x"))).withColumnRenamed("multiply_func(x, x)", "squared")
 
 def persist(df, table_path):
-	df.write.format("parquet").mode("overwrite").save(table_path)
+	df.write.format("delta").mode("overwrite").save(table_path)
 	

--- a/tests/test_udfs.py
+++ b/tests/test_udfs.py
@@ -5,7 +5,7 @@ from pyspark.sql import SparkSession
 from lib.udfs import xform, persist
 
 class TestUDFs(object):
-    spark = SparkSession.builder.master("local").appName("hw_tests").getOrCreate()
+    spark = SparkSession.builder.master("local").config("spark.jars.packages", "io.delta:delta-core_2.12:0.1.0").config("spark.driver.host", "localhost").appName("hw_tests").getOrCreate()
 
     def test_xform(self):
 
@@ -30,9 +30,9 @@ class TestUDFs(object):
 
     	ip_df = self.spark.createDataFrame(pd.DataFrame(ip, columns=["x"]))
 
-    	persist(ip_df, "/tmp/roy/hw_parquet_table")
+    	persist(ip_df, "/tmp/roy/hw_delta_table")
 
-    	op_df = self.spark.read.format("parquet").load("/tmp/roy/hw_parquet_table")
+    	op_df = self.spark.read.format("delta").load("/tmp/roy/hw_delta_table")
 
     	ex_df = self.spark.createDataFrame(pd.DataFrame(ip, columns=["x"]))
 


### PR DESCRIPTION
Spark 2.4.2 with `SparkSession.builder.master("local").config("spark.jars.packages", "io.delta:delta-core_2.12:0.1.0").appName("hw_tests").getOrCreate()` in pyspark fails with:

```
________________________________________________________________________ TestUDFs.test_persist ________________________________________________________________________

self = <tests.test_udfs.TestUDFs object at 0x10aedc850>

    def test_persist(self):

    	print(self.spark.version)

    	ip = pd.Series([10, 11, 12])

    	ip_df = self.spark.createDataFrame(pd.DataFrame(ip, columns=["x"]))

>   	persist(ip_df, "/tmp/roy/hw_delta_table")

tests/test_udfs.py:33:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
lib/udfs.py:12: in persist
    df.write.format("delta").mode("overwrite").save(table_path)
/usr/local/lib/python2.7/site-packages/pyspark/sql/readwriter.py:734: in save
    self._jwrite.save(path)
/usr/local/lib/python2.7/site-packages/py4j/java_gateway.py:1257: in __call__
    answer, self.gateway_client, self.target_id, self.name)
/usr/local/lib/python2.7/site-packages/pyspark/sql/utils.py:63: in deco
    return f(*a, **kw)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

answer = 'xro175', gateway_client = <py4j.java_gateway.GatewayClient object at 0x109c86810>, target_id = 'o174', name = 'save'

    def get_return_value(answer, gateway_client, target_id=None, name=None):
        """Converts an answer received from the Java gateway into a Python object.

        For example, string representation of integers are converted to Python
        integer, string representation of objects are converted to JavaObject
        instances, etc.

        :param answer: the string returned by the Java gateway
        :param gateway_client: the gateway client used to communicate with the Java
            Gateway. Only necessary if the answer is a reference (e.g., object,
            list, map)
        :param target_id: the name of the object from which the answer comes from
            (e.g., *object1* in `object1.hello()`). Optional.
        :param name: the name of the member from which the answer comes from
            (e.g., *hello* in `object1.hello()`). Optional.
        """
        if is_error(answer)[0]:
            if len(answer) > 1:
                type = answer[1]
                value = OUTPUT_CONVERTER[type](answer[2:], gateway_client)
                if answer[1] == REFERENCE_TYPE:
                    raise Py4JJavaError(
                        "An error occurred while calling {0}{1}{2}.\n".
>                       format(target_id, ".", name), value)
E                   Py4JJavaError: An error occurred while calling o174.save.
E                   : java.util.ServiceConfigurationError: org.apache.spark.sql.sources.DataSourceRegister: Provider org.apache.spark.sql.delta.sources.DeltaDataSource could not be instantiated
E                   	at java.util.ServiceLoader.fail(ServiceLoader.java:232)
E                   	at java.util.ServiceLoader.access$100(ServiceLoader.java:185)
E                   	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:384)
E                   	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
E                   	at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
E                   	at scala.collection.convert.Wrappers$JIteratorWrapper.next(Wrappers.scala:44)
E                   	at scala.collection.Iterator.foreach(Iterator.scala:941)
E                   	at scala.collection.Iterator.foreach$(Iterator.scala:941)
E                   	at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
E                   	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
E                   	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
E                   	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
E                   	at scala.collection.TraversableLike.filterImpl(TraversableLike.scala:250)
E                   	at scala.collection.TraversableLike.filterImpl$(TraversableLike.scala:248)
E                   	at scala.collection.AbstractTraversable.filterImpl(Traversable.scala:108)
E                   	at scala.collection.TraversableLike.filter(TraversableLike.scala:262)
E                   	at scala.collection.TraversableLike.filter$(TraversableLike.scala:262)
E                   	at scala.collection.AbstractTraversable.filter(Traversable.scala:108)
E                   	at org.apache.spark.sql.execution.datasources.DataSource$.lookupDataSource(DataSource.scala:630)
E                   	at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:245)
E                   	at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:229)
E                   	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
E                   	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
E                   	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
E                   	at java.lang.reflect.Method.invoke(Method.java:498)
E                   	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
E                   	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:380)
E                   	at py4j.Gateway.invoke(Gateway.java:295)
E                   	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
E                   	at py4j.commands.CallCommand.execute(CallCommand.java:79)
E                   	at py4j.GatewayConnection.run(GatewayConnection.java:251)
E                   	at java.lang.Thread.run(Thread.java:748)
E                   Caused by: java.lang.VerifyError: Cannot inherit from final class
E                   	at java.lang.ClassLoader.defineClass1(Native Method)
E                   	at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
E                   	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
E                   	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
E                   	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
E                   	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
E                   	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
E                   	at java.security.AccessController.doPrivileged(Native Method)
E                   	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
E                   	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
E                   	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
E                   	at java.lang.Class.getDeclaredConstructors0(Native Method)
E                   	at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
E                   	at java.lang.Class.getConstructor0(Class.java:3075)
E                   	at java.lang.Class.newInstance(Class.java:412)
E                   	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:380)
E                   	... 29 more

/usr/local/lib/python2.7/site-packages/py4j/protocol.py:328: Py4JJavaError
------------------------------------------------------------------------ Captured stdout call -------------------------------------------------------------------------
2.4.2

```